### PR TITLE
Only calc encoder z if logging, remove uneeded scaling

### DIFF
--- a/dreamer4/interactive.py
+++ b/dreamer4/interactive.py
@@ -258,6 +258,7 @@ def load_tokenizer_from_ckpt(tokenizer_ckpt: str, device: torch.device):
     dropout = float(a.get("dropout", 0.0))
     mlp_ratio = float(a.get("mlp_ratio", 4.0))
     time_every = int(a.get("time_every", 1))
+    scale_pos_embeds = bool(a.get("scale_pos_embeds", True))
 
     assert H % patch == 0 and W % patch == 0
     n_patches = (H // patch) * (W // patch)
@@ -276,6 +277,7 @@ def load_tokenizer_from_ckpt(tokenizer_ckpt: str, device: torch.device):
         time_every=time_every,
         mae_p_min=0.0,
         mae_p_max=0.0,
+        scale_pos_embeds=scale_pos_embeds,
     )
     dec = Decoder(
         d_bottleneck=d_bottleneck,
@@ -288,6 +290,7 @@ def load_tokenizer_from_ckpt(tokenizer_ckpt: str, device: torch.device):
         dropout=dropout,
         mlp_ratio=mlp_ratio,
         time_every=time_every,
+        scale_pos_embeds=scale_pos_embeds,
     )
     tok = Tokenizer(enc, dec).to(device)
     tok.load_state_dict(_get_state_dict(ckpt), strict=True)
@@ -320,6 +323,7 @@ def load_dynamics_from_ckpt(
     n_register = int(a.get("n_register", 4))
     n_agent = int(a.get("n_agent", 0))
     space_mode = str(a.get("space_mode", a.get("agent_space_mode", "wm_agent_isolated")))
+    scale_pos_embeds = bool(a.get("scale_pos_embeds", True))
 
     assert n_latents % packing_factor == 0
     n_spatial = n_latents // packing_factor
@@ -339,6 +343,7 @@ def load_dynamics_from_ckpt(
         mlp_ratio=mlp_ratio,
         time_every=time_every,
         space_mode=space_mode,
+        scale_pos_embeds=scale_pos_embeds,
     ).to(device)
     dyn.load_state_dict(_get_state_dict(ckpt), strict=True)
     dyn.eval()

--- a/dreamer4/model.py
+++ b/dreamer4/model.py
@@ -94,7 +94,7 @@ def add_sinusoidal_positions(tokens_btSd: torch.Tensor) -> torch.Tensor:
     device = tokens_btSd.device
     pos_t = sinusoid_table(T, D, device=device)  # fp32
     pos_s = sinusoid_table(S, D, device=device)  # fp32
-    pos = (pos_t[None, :, None, :] + pos_s[None, None, :, :]) * (1.0 / math.sqrt(D))
+    pos = (pos_t[None, :, None, :] + pos_s[None, None, :, :])
     return tokens_btSd + pos.to(dtype=tokens_btSd.dtype)
 
 

--- a/dreamer4/train_tokenizer.py
+++ b/dreamer4/train_tokenizer.py
@@ -134,6 +134,7 @@ def save_ckpt(path: Path, *, step: int, epoch: int, model, opt, scaler, args: ar
         "opt": opt.state_dict(),
         "scaler": scaler.state_dict() if scaler is not None else None,
         "args": vars(args),
+        "scale_pos_embeds": args.scale_pos_embeds,
     }
     tmp = path.with_suffix(".tmp")
     torch.save(obj, tmp)
@@ -198,6 +199,7 @@ def train(args):
         time_every=args.time_every,
         mae_p_min=args.mae_p_min,
         mae_p_max=args.mae_p_max,
+        scale_pos_embeds=args.scale_pos_embeds,
     )
     dec = Decoder(
         d_bottleneck=args.d_bottleneck,
@@ -210,6 +212,7 @@ def train(args):
         dropout=args.dropout,
         mlp_ratio=args.mlp_ratio,
         time_every=args.time_every,
+        scale_pos_embeds=args.scale_pos_embeds,
     )
     model = Tokenizer(enc, dec).to(device)
 
@@ -402,6 +405,10 @@ if __name__ == "__main__":
     p.add_argument("--time_every", type=int, default=1)
     p.add_argument("--mae_p_min", type=float, default=0.0)
     p.add_argument("--mae_p_max", type=float, default=0.9)
+
+    # Better performance without scale_pos_embeds (set to False)
+    # Set to True by default for backwards compatibility. Details here: https://github.com/nicklashansen/dreamer4/pull/4
+    p.add_argument("--scale_pos_embeds", action="store_true")
 
     # optim
     p.add_argument("--lr", type=float, default=1e-4)

--- a/dreamer4/train_tokenizer.py
+++ b/dreamer4/train_tokenizer.py
@@ -277,8 +277,8 @@ def train(args):
                 patches = temporal_patchify(x, args.patch)
 
                 with torch.no_grad():
-                    z, _ = (model.module.encoder if hasattr(model, "module") else model.encoder)(patches)
                     if is_rank0() and step % args.log_every == 0:
+                        z, _ = (model.module.encoder if hasattr(model, "module") else model.encoder)(patches)
                         wandb.log({"debug/z_std": float(z.float().std().item())}, step=step)
 
                 with autocast(device_type="cuda", enabled=use_amp):


### PR DESCRIPTION
This PR fixes 2 things:

* There was a forward pass of the encoder on every step. This was shifted into the `if` statement so it's only run when logging `z_std`
* Position embeddings were scaled by `(1.0 / math.sqrt(D))`. In the original MAE paper implementation [here](https://github.com/facebookresearch/mae/blob/main/models_mae.py#L155), they just add the embeddings. Scaling them by `(1.0 / math.sqrt(D))` makes it harder for the model to learn fine details, especially when training at BF16/FP16.
    * Personal empirical results show better performance without scaling 
    * `F.scaled_dot_product_attention` already scales for attention